### PR TITLE
feat: Implement frontend for DARF control, bulk delete, and tax table

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -89,6 +89,11 @@ class ResultadoMensal(BaseModel):
     darf_competencia: Optional[str] = None
     darf_valor: Optional[float] = None
     darf_vencimento: Optional[date] = None
+    vendas_day_trade: Optional[float] = Field(default=0.0)
+    darf_swing_trade_valor: Optional[float] = Field(default=0.0)
+    darf_day_trade_valor: Optional[float] = Field(default=0.0)
+    status_darf_swing_trade: Optional[str] = Field(default=None)
+    status_darf_day_trade: Optional[str] = Field(default=None)
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/components/Dashboard.tsx
+++ b/frontend/components/Dashboard.tsx
@@ -122,7 +122,7 @@ export function Dashboard() {
           </TabsContent>
 
           <TabsContent value="taxes">
-            <TaxResults resultados={data.resultados} />
+            <TaxResults resultados={data.resultados} onUpdate={handleDataUpdate} />
           </TabsContent>
 
           <TabsContent value="history">

--- a/frontend/components/OperationsHistory.tsx
+++ b/frontend/components/OperationsHistory.tsx
@@ -21,6 +21,7 @@ export function OperationsHistory({ operacoes, onUpdate }: OperationsHistoryProp
   const [searchTicker, setSearchTicker] = useState("")
   const [filterOperation, setFilterOperation] = useState("all")
   const [loading, setLoading] = useState<number | null>(null)
+  const [bulkDeleting, setBulkDeleting] = useState(false); // State for bulk delete
   const { toast } = useToast()
 
   const filteredOperations = operacoes.filter((op) => {
@@ -50,6 +51,30 @@ export function OperationsHistory({ operacoes, onUpdate }: OperationsHistoryProp
       setLoading(null)
     }
   }
+
+  const handleBulkDelete = async () => {
+    if (!confirm("Tem certeza que deseja excluir TODAS as operações? Esta ação não pode ser desfeita.")) {
+      return;
+    }
+
+    setBulkDeleting(true);
+    try {
+      const response = await api.delete("/operacoes/all");
+      toast({
+        title: "Sucesso!",
+        description: response.data.mensagem || "Todas as operações foram excluídas.",
+      });
+      onUpdate(); // Refresh data
+    } catch (error: any) {
+      toast({
+        title: "Erro",
+        description: error.response?.data?.detail || "Erro ao excluir todas as operações.",
+        variant: "destructive",
+      });
+    } finally {
+      setBulkDeleting(false);
+    }
+  };
 
   const formatCurrency = (value: number) => {
     return new Intl.NumberFormat("pt-BR", {
@@ -96,8 +121,20 @@ export function OperationsHistory({ operacoes, onUpdate }: OperationsHistoryProp
           </div>
         </div>
 
+        {/* Bulk Delete Button */}
+        <div className="mt-4">
+          <Button
+            variant="destructive"
+            onClick={handleBulkDelete}
+            disabled={bulkDeleting || operacoes.length === 0}
+            className="w-full sm:w-auto" // Full width on small screens, auto on larger
+          >
+            {bulkDeleting ? "Excluindo..." : "Excluir Todas as Operações"}
+          </Button>
+        </div>
+
         {/* Tabela */}
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto mt-4"> {/* Added mt-4 for spacing */}
           <Table>
             <TableHeader>
               <TableRow>

--- a/frontend/components/TaxResults.tsx
+++ b/frontend/components/TaxResults.tsx
@@ -3,16 +3,49 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
+import { useState } from "react" // Added for darfUpdating state
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button" // Added Button import
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Calendar, DollarSign, TrendingUp, AlertTriangle, CheckCircle } from "lucide-react"
+import { Calendar, DollarSign, TrendingUp, AlertTriangle, CheckCircle, Edit3 } from "lucide-react" // Edit3 for actions
 import type { ResultadoMensal } from "@/lib/types"
+import { api } from "@/lib/api" // Added api import
+import { useToast } from "@/hooks/use-toast" // Added useToast import
 
 interface TaxResultsProps {
   resultados: ResultadoMensal[]
+  onUpdate: () => void; // Added onUpdate prop
 }
 
-export function TaxResults({ resultados }: TaxResultsProps) {
-  const formatCurrency = (value: number) => {
+export function TaxResults({ resultados, onUpdate }: TaxResultsProps) { // Destructure onUpdate
+  const { toast } = useToast() // Initialize toast
+  const [darfUpdating, setDarfUpdating] = useState<string | null>(null);
+
+  const handleMarkAsPaid = async (yearMonth: string, type: 'swing' | 'daytrade') => {
+    const darfId = `${yearMonth}-${type}`;
+    setDarfUpdating(darfId);
+    try {
+      await api.put(`/impostos/darf_status/${yearMonth}/${type}`, { status: "Pago" });
+      toast({
+        title: "Sucesso!",
+        description: `DARF ${type === 'swing' ? 'Swing Trade' : 'Day Trade'} de ${formatMonth(yearMonth)} marcado como Pago.`,
+      });
+      onUpdate();
+    } catch (error: any) {
+      toast({
+        title: "Erro",
+        description: error.response?.data?.detail || `Erro ao marcar DARF como pago.`,
+        variant: "destructive",
+      });
+    } finally {
+      setDarfUpdating(null);
+    }
+  };
+
+  const formatCurrency = (value: number | undefined | null) => { // Allow undefined/null
+    if (value === undefined || value === null) return "-";
     return new Intl.NumberFormat("pt-BR", {
       style: "currency",
       currency: "BRL",
@@ -196,6 +229,110 @@ export function TaxResults({ resultados }: TaxResultsProps) {
           </CardContent>
         </Card>
       )}
+
+      {/* Informações Importantes */}
+      {/* Controle de DARFs Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Controle de Pagamento de DARFs</CardTitle>
+          <CardDescription>Gerencie o status de pagamento dos seus DARFs mensais.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Mês</TableHead>
+                  <TableHead className="text-right">Vendas Swing</TableHead>
+                  <TableHead className="text-right">Resultado ST</TableHead>
+                  <TableHead className="text-right">DARF ST (R$)</TableHead>
+                  <TableHead className="text-center">Status ST</TableHead>
+                  <TableHead className="text-right">Vendas Day Trade</TableHead>
+                  <TableHead className="text-right">Resultado DT</TableHead>
+                  <TableHead className="text-right">DARF DT (R$)</TableHead>
+                  <TableHead className="text-center">Status DT</TableHead>
+                  <TableHead className="text-center">Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {resultados.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={10} className="text-center py-8 text-muted-foreground">
+                      Nenhum resultado mensal encontrado.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  resultados.map((resultado) => (
+                    <TableRow key={`controle-${resultado.mes}`}>
+                      <TableCell className="font-medium">{formatMonth(resultado.mes)}</TableCell>
+                      <TableCell className="text-right">{formatCurrency(resultado.vendas_swing)}</TableCell>
+                      <TableCell className={`text-right ${resultado.ganho_liquido_swing >= 0 ? "text-green-600" : "text-red-600"}`}>
+                        {formatCurrency(resultado.ganho_liquido_swing)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        { (resultado.darf_swing_trade_valor && resultado.darf_swing_trade_valor > 0)
+                          ? <Badge variant="outline">{formatCurrency(resultado.darf_swing_trade_valor)}</Badge>
+                          : <span className="text-muted-foreground">-</span>}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        {resultado.status_darf_swing_trade ? (
+                          <Badge variant={resultado.status_darf_swing_trade === 'Pago' ? 'success' : 'warning'}>
+                            {resultado.status_darf_swing_trade}
+                          </Badge>
+                        ) : <span className="text-muted-foreground">-</span>}
+                      </TableCell>
+                      <TableCell className="text-right">{formatCurrency(resultado.vendas_day_trade)}</TableCell>
+                      <TableCell className={`text-right ${resultado.ganho_liquido_day >= 0 ? "text-green-600" : "text-red-600"}`}>
+                        {formatCurrency(resultado.ganho_liquido_day)}
+                      </TableCell>
+                       <TableCell className="text-right">
+                        { (resultado.darf_day_trade_valor && resultado.darf_day_trade_valor > 0)
+                          ? <Badge variant="destructive">{formatCurrency(resultado.darf_day_trade_valor)}</Badge>
+                          : <span className="text-muted-foreground">-</span>}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        {resultado.status_darf_day_trade ? (
+                          <Badge variant={resultado.status_darf_day_trade === 'Pago' ? 'success' : 'warning'}>
+                            {resultado.status_darf_day_trade}
+                          </Badge>
+                        ) : <span className="text-muted-foreground">-</span>}
+                      </TableCell>
+                      <TableCell className="text-center space-x-1">
+                        {resultado.status_darf_swing_trade === 'Pendente' && resultado.darf_swing_trade_valor && resultado.darf_swing_trade_valor > 0 && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleMarkAsPaid(resultado.mes, 'swing')}
+                            disabled={darfUpdating === `${resultado.mes}-swing`}
+                            className="text-xs h-7 px-2"
+                          >
+                            {darfUpdating === `${resultado.mes}-swing` ? "..." : "Pagar ST"}
+                          </Button>
+                        )}
+                        {resultado.status_darf_day_trade === 'Pendente' && resultado.darf_day_trade_valor && resultado.darf_day_trade_valor > 0 && (
+                           <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleMarkAsPaid(resultado.mes, 'daytrade')}
+                            disabled={darfUpdating === `${resultado.mes}-daytrade`}
+                            className="text-xs h-7 px-2"
+                          >
+                            {darfUpdating === `${resultado.mes}-daytrade` ? "..." : "Pagar DT"}
+                          </Button>
+                        )}
+                         {!(resultado.status_darf_swing_trade === 'Pendente' && resultado.darf_swing_trade_valor && resultado.darf_swing_trade_valor > 0) &&
+                          !(resultado.status_darf_day_trade === 'Pendente' && resultado.darf_day_trade_valor && resultado.darf_day_trade_valor > 0) &&
+                           <span className="text-muted-foreground text-xs">-</span>
+                        }
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Informações Importantes */}
       <Card>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -26,4 +26,9 @@ export interface ResultadoMensal {
   ir_pagar_day: number;
   darf_codigo?: string;
   darf_vencimento?: string; // YYYY-MM-DD
+  vendas_day_trade?: number;
+  darf_swing_trade_valor?: number;
+  darf_day_trade_valor?: number;
+  status_darf_swing_trade?: string; // e.g., 'Pendente', 'Pago'
+  status_darf_day_trade?: string; // e.g., 'Pendente', 'Pago'
 }


### PR DESCRIPTION
This commit introduces the frontend changes to support the recently implemented backend functionalities for DARF control, bulk operations deletion, and the enhanced tax table.

Key changes:

1.  **Bulk Delete in Operations History (`OperationsHistory.tsx`):**
    *   Added an "Excluir Todas as Operações" button.
    *   Includes a confirmation dialog before deletion.
    *   Calls the `DELETE /api/operacoes/all` endpoint.
    *   Provides toast notifications for success/error and uses the `onUpdate` prop to refresh data.
    *   Includes a loading state for the button.

2.  **Enhanced Tax Results Table (`TaxResults.tsx`):**
    *   Added a new "Controle de Pagamento de DARFs" table.
    *   This table displays new `ResultadoMensal` fields: Vendas Day Trade, DARF Swing Trade (valor), Status Swing Trade, DARF Day Trade (valor), and Status Day Trade.
    *   Monetary values are formatted, and statuses are displayed using badges.

3.  **Mark DARF as Paid Functionality (`TaxResults.tsx`):**
    *   Added "Pagar ST" / "Pagar DT" buttons within the "Controle de Pagamento de DARFs" table for DARFs with a 'Pendente' status and value > 0.
    *   These buttons call the `PUT /api/impostos/darf_status/:year_month/:type` endpoint with `{"status": "Pago"}`.
    *   Includes loading states for individual buttons and toast notifications for feedback.
    *   The component now accepts and uses an `onUpdate` prop to refresh dashboard data after a status update.

4.  **Dashboard Integration (`Dashboard.tsx`):**
    *   The `onUpdate` prop (which triggers `fetchDashboardData`) is now passed to `TaxResults` to ensure data consistency after DARF status updates.

These changes complete the user-facing aspects of the DARF control and bulk operations management features, providing you with a more comprehensive and interactive experience.